### PR TITLE
Update README: fix example's transmission config

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ systemd.services.<name>.vpnConfinement = {
   services.transmission = {
     enable = true;
     settings = {
-      "rpc-bind-address" = "192.168.15.1"; # Bind RPC/WebUI to bridge address
+      "rpc-bind-address" = "192.168.15.1"; # Bind RPC/WebUI to VPN namespace address
+      "rpc-whitelist" = "192.168.15.5"; # Allow RPC/WebUI access from bridge on the default namespace
     };
   };
 }


### PR DESCRIPTION
I can't access the Web GUI with the given example.

Upon accessing the GUI (http://192.168.15.1:9091), the following error is shown:

> 403: Forbidden
> Unauthorized IP Address.
> Either disable the IP address whitelist or add your address to it.
> If you're editing settings.json, see the 'rpc-whitelist' and 'rpc-whitelist-enabled' entries.
> If you're still using ACLs, use a whitelist instead. See the transmission-daemon manpage for details.


I think the errors lie within an incomplete transmission config:
```
services.transmission = {
    enable = true;
    settings = {
      "rpc-bind-address" = "192.168.15.1"; # Bind RPC/WebUI to bridge address
    };
  };
```

1. The comment seems wrong: isn't this the `namespaceAddress` instead of the `bridgeAddress` ?
2. As transmission's verbose error stated, `rpc-whitelist` is missing.

This works for me:
```
services.transmission = {
    enable = true;
    settings = {
      "rpc-bind-address" = "192.168.15.1"; # Bind RPC to vpn namespace address
      "rpc-whitelist" = "192.168.15.5"; # Allow WebUI access from bridge on the default namespace
    };
  };
```