### PR TITLE
fix endpoint connectivity check to support ipv6 endpoint address

### DIFF
--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -114,9 +114,14 @@ pkgs.writeShellApplication {
       echo "$WG_CONFIG"
     }
 
-    # Wait for wireguard endpoint to be reachable
+    # The wireguard endpoint is an IP address with a port. Extract the address alone, and test for
+    # connectivity using ping.
     # shellcheck disable=SC2154
-    until ping -c1 "''${Endpoint%%:*}" > /dev/null 2>&1; do
+    EndpointIP="''${Endpoint%:*}"  # Remove port
+    EndpointIP="''${EndpointIP#[}" # Remove leading bracket in case of an IPv6 address
+    EndpointIP="''${EndpointIP%]}" # Remove trailing bracket in case of an IPv6 address
+    echo "Waiting for wireguard endpoint $EndpointIP to be reachable..."
+    until ping -c1 "''$EndpointIP" > /dev/null 2>&1; do
       sleep 1
     done
 

--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -1,7 +1,7 @@
-{
-  pkgs,
-  lib,
-  optionalIPv6String,
+{ pkgs
+, lib
+, optionalIPv6String
+,
 }:
 netnsName: def:
 let
@@ -117,13 +117,28 @@ pkgs.writeShellApplication {
     # The wireguard endpoint is an IP address with a port. Extract the address alone, and test for
     # connectivity using ping.
     # shellcheck disable=SC2154
-    EndpointIP="''${Endpoint%:*}"  # Remove port
-    EndpointIP="''${EndpointIP#[}" # Remove leading bracket in case of an IPv6 address
-    EndpointIP="''${EndpointIP%]}" # Remove trailing bracket in case of an IPv6 address
-    echo "Waiting for wireguard endpoint $EndpointIP to be reachable..."
-    until ping -c1 "''$EndpointIP" > /dev/null 2>&1; do
+    if [[ $Endpoint =~ ^\[?([^]]+)\]?:[0-9]+$ ]]; then
+      EndpointIP="''${BASH_REMATCH[1]}"
+    else
+      echo "invalid endpoint format: '$Endpoint'" >&2
+      exit 1
+    fi
+
+    max_retries=5
+    success=false
+    echo -n "Waiting for wireguard endpoint $EndpointIP to be reachable..."
+    for _ in $(seq 1 $max_retries); do
+      ping -c1 "$EndpointIP" > /dev/null 2>&1 && { success=true; break; }
       sleep 1
     done
+
+    if ! $success; then
+      echo # The last echo did not print a newline, print one now
+      echo "failed to reach '$EndpointIP' after $max_retries attempts" >&2
+      exit 1
+    else
+      echo " success!"
+    fi
 
     # Set wireguard config
     ip netns exec ${netnsName} \

--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -124,7 +124,7 @@ pkgs.writeShellApplication {
       exit 1
     fi
 
-    max_retries=5
+    max_retries=30
     success=false
     echo -n "Waiting for wireguard endpoint $EndpointIP to be reachable..."
     for _ in $(seq 1 $max_retries); do

--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -1,7 +1,7 @@
-{ pkgs
-, lib
-, optionalIPv6String
-,
+{
+  pkgs,
+  lib,
+  optionalIPv6String,
 }:
 netnsName: def:
 let

--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -124,7 +124,7 @@ pkgs.writeShellApplication {
       exit 1
     fi
 
-    max_retries=30
+    max_retries=5
     success=false
     echo -n "Waiting for wireguard endpoint $EndpointIP to be reachable..."
     for _ in $(seq 1 $max_retries); do


### PR DESCRIPTION
This is such a helpful project! As someone without much network configuration experience, I've been enjoying looking through the code to learn about how things work.

When I set this up on my machine I noticed that the vpn namespace service got stuck waiting for a successful ping of the wireguard endpoint. I'm using an IPv6 endpoint, and it turns out is was running `ping -c1 "[2607"` since the existing expression to parse the address from the address-port pair trimmed everything from the first colon instead of the last colon.

I believe this change correctly handles both IPv4 and IPv6 endpoints. For IPv6 it is necessary to remove square brackets from the address in addition to trimming from the last instead of the first colon. I also added an echo statement so that if an address is not parsed correctly for any reason it will be clear from the systemd unit logs what went wrong.

I thought it might also be helpful to abort the script after some number of failed retries. That way there would be a clear failure notification if the endpoint is not reachable. In the current implementation if the pings fail the `nixos-rebuild` command hangs forever, and I don't think the vpn namespace service shows up in a listing of failed units. What do you think?