### PR TITLE
fix endpoint connectivity retries

### DIFF
--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -124,12 +124,14 @@ pkgs.writeShellApplication {
       exit 1
     fi
 
+    attempt=1
     max_retries=5
     success=false
-    echo -n "Waiting for wireguard endpoint $EndpointIP to be reachable..."
-    for _ in $(seq 1 $max_retries); do
-      ping -c1 "$EndpointIP" > /dev/null 2>&1 && { success=true; break; }
+    echo -n "Waiting for wireguard endpoint '$EndpointIP' to be reachable..."
+    while [[ $attempt -le $max_retries ]]; do
+      ping -c 1 "$EndpointIP" > /dev/null 2>&1 && { success=true; break; }
       sleep 1
+      attempt=$((attempt + 1))
     done
 
     if ! $success; then


### PR DESCRIPTION
I noticed the service was immediately failing on start-up after a single ping failure. It was due to the `for _ in $(seq 1 $max_retries); do` loop here:
https://github.com/Maroka-chan/VPN-Confinement/blob/f2989e1e3cb06c7185939e9ddc368f88b998616a/modules/vpn-up.nix#L127-L133

As previously in the script `IFS` is set to "," meaning the loop doesn't run as expected.

I've replaced it with a while loop which should be more robust.