### PR TITLE
fix(systemd): tolerate missing nscd/resolvconf paths

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -49,8 +49,8 @@ in {
                 NetworkNamespacePath = "/run/netns/${vpn}";
 
                 InaccessiblePaths = [
-                  "/run/nscd"
-                  "/run/resolvconf"
+                  "-/run/nscd"
+                  "-/run/resolvconf"
                 ];
 
                 BindReadOnlyPaths = [


### PR DESCRIPTION
`InaccessiblePaths=/run/nscd` (and `/run/resolvconf`) fails the unit with `status=226/NAMESPACE` when the path does not exist on the host. This happens when nscd is disabled, resolvconf is not in use, or nscd's `RuntimeDirectory` has not materialised yet at unit start. 

(noticed then when I was restarting my server and sometimes confined services failed)

Solution: Per `systemd.exec(5)`, the `-` prefix makes the entry optional; i.e, Missing path is ignored instead of fatal. Behaviour when the path exists should be unchanged.