### PR TITLE
fix: force DNS traffic through WireGuard to avoid accessibleFrom route conflict

### DIFF
--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -191,6 +191,45 @@ in
         )
         def.accessibleFrom}
 
+      # Force all DNS traffic through the WireGuard interface via policy routing.
+      # Port 53 lookups use table 51820, so accessibleFrom routes in main are never consulted for DNS.
+      # If the tunnel drops, table 51820 empties and the lookup falls through to main,
+      # which would send queries over the veth. The dns-leak chain below drops those packets before they escape.
+
+      ip -n ${netnsName} route add default dev ${netnsName}0 table 51820
+
+      ip -n ${netnsName} rule add ipproto udp dport 53 lookup 51820 priority 100
+      ip -n ${netnsName} rule add ipproto tcp dport 53 lookup 51820 priority 100
+
+      # Guard against DNS leaks when the WireGuard tunnel is down.
+      # Monitor dropped packets with:
+      #   sudo ip netns exec ${netnsName} iptables -L dns-leak -v -n
+      ip netns exec ${netnsName} iptables -N dns-leak
+
+      ip netns exec ${netnsName} iptables -A dns-leak \
+        -m limit --limit 1/min -j LOG --log-prefix "dns-leak: "
+      ip netns exec ${netnsName} iptables -A dns-leak -j DROP
+
+      ip netns exec ${netnsName} iptables -I OUTPUT 1 -o veth-${netnsName} \
+        -p udp --dport 53 -j dns-leak
+      ip netns exec ${netnsName} iptables -I OUTPUT 1 -o veth-${netnsName} \
+        -p tcp --dport 53 -j dns-leak
+
+      ${optionalIPv6String ''
+        ip -6 -n ${netnsName} route add default dev ${netnsName}0 table 51820
+        ip -6 -n ${netnsName} rule add ipproto udp dport 53 lookup 51820 priority 100
+        ip -6 -n ${netnsName} rule add ipproto tcp dport 53 lookup 51820 priority 100
+
+        ip netns exec ${netnsName} ip6tables -N dns-leak
+        ip netns exec ${netnsName} ip6tables -A dns-leak \
+          -m limit --limit 1/min -j LOG --log-prefix "dns-leak6: "
+        ip netns exec ${netnsName} ip6tables -A dns-leak -j DROP
+        ip netns exec ${netnsName} ip6tables -I OUTPUT 1 -o veth-${netnsName} \
+          -p udp --dport 53 -j dns-leak
+        ip netns exec ${netnsName} ip6tables -I OUTPUT 1 -o veth-${netnsName} \
+          -p tcp --dport 53 -j dns-leak
+      ''}
+
       # Add prerouting rules
       iptables -t nat -N ${netnsName}-prerouting
       iptables -t nat -A PREROUTING -j ${netnsName}-prerouting

--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -200,7 +200,7 @@ in
       ip -n ${netnsName} rule add ipproto udp dport 53 lookup 51820 priority 100
       ip -n ${netnsName} rule add ipproto tcp dport 53 lookup 51820 priority 100
 
-      # Guard against DNS leaks when the WireGuard tunnel is down.
+      # Guard against DNS leaks when routing table ('51820') is not present.
       # Monitor dropped packets with:
       #   sudo ip netns exec ${netnsName} iptables -L dns-leak -v -n
       ip netns exec ${netnsName} iptables -N dns-leak

--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -191,10 +191,9 @@ in
         )
         def.accessibleFrom}
 
-      # Force all DNS traffic through the WireGuard interface via policy routing.
-      # Port 53 lookups use table 51820, so accessibleFrom routes in main are never consulted for DNS.
-      # If the tunnel drops, table 51820 empties and the lookup falls through to main,
-      # which would send queries over the veth. The dns-leak chain below drops those packets before they escape.
+      # Force all DNS traffic (port 53 TCP/UDP) through the WireGuard interface via policy routing.
+      # Traffic on port 53 uses a separate routing table ('51820') so it always exits through the WireGuard interface. This prevents DNS lookups from passing through the veth pair when the nameserver appears in the main routing table. This in practice means that DNS is not leaked when a nameserver is specified in the 'accessibleFrom' option.
+      # As a failsafe, the 'dns-leak' chain drops any DNS traffic that falls through to the main table. This can happen if the WireGuard interface or the '51820' route is removed.
 
       ip -n ${netnsName} route add default dev ${netnsName}0 table 51820
 


### PR DESCRIPTION
First and foremost, thank you for this great project.

## Problem

I contribute to [Nixarr](https://github.com/nix-media-server/nixarr), which uses this module extensively. One of my changes ([nixarr#171](https://github.com/nix-media-server/nixarr/pull/171)) added all RFC 1918 ranges to `accessibleFrom` so services can be exposed on LAN.
This broke DNS (it's always DNS), because some VPN providers use `10.x.x.x` (ProtonVPN `10.2.0.1`; MullvadVPN `10.64.0.1`) addresses for their DNS resolvers, which unfortunately matches the `accessibleFrom` route and gets sent over `veth` instead of the tunnel.

## Changes

### Policy routing (table 51820)

All traffic with destination port 53 (UDP + TCP, v4 + v6) is forced into routing table 51820, which has a single default route through the WireGuard interface. DNS lookups always go through the tunnel regardless of what `accessibleFrom` routes exist.

If the `wg0` interface drops, table 51820 empties and the routing lookup falls through to `main`, which would send queries over `veth` again. The `dns-leak` chain catches those packets on the veth output path and DROPs them.

This does mean all DNS lookups are hardwired through the tunnel, preventing local DNS resolution.

## Testing

If automated tests are necessary, I could look into it but I only tested the `dns-leak` manually.

```bash
sudo ip netns exec wg iptables -Z dns-leak
sudo ip -n wg link set wg0 down
sudo ip netns exec wg dig +time=1 +tries=1 @10.2.0.1 example.com
sudo ip netns exec wg iptables -L dns-leak -v -n
sudo ip -n wg link set wg0 up
```

The command `ip netns exec wg iptables -L dns-leak -v -n` also serves as a sanity check. If the counter stays at 0, it means not a single DNS request tried escaping the `veth`.

I am aware that this whole fix only addresses DNS resolution over port 53 ignoring DoT and DoH.
As far as I understand this could be handled in a similar way,  but I am unsure of the overall implications. As the saying goes - never touch a running system.

Please let me know if there is something unclear or changes are needed!