### PR TITLE
feat: drop outgoing packets via the veth

### DIFF
--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -183,17 +183,29 @@ in
             if isValidIPv4 x
             then ''
               ip -n ${netnsName} route add ${x} via ${def.bridgeAddress}
+              ip netns exec ${netnsName} iptables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+              ip netns exec ${netnsName} iptables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate NEW -j DROP
             ''
             else
               optionalIPv6String ''
                 ip -n ${netnsName} route add ${x} via ${def.bridgeAddressIPv6}
+                ip netns exec ${netnsName} ip6tables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+                ip netns exec ${netnsName} ip6tables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate NEW -j DROP
               ''
         )
         def.accessibleFrom}
 
-      # Force all DNS traffic (port 53 TCP/UDP) through the WireGuard interface via policy routing.
-      # Traffic on port 53 uses a separate routing table ('51820') so it always exits through the WireGuard interface. This prevents DNS lookups from passing through the veth pair when the nameserver appears in the main routing table. This in practice means that DNS is not leaked when a nameserver is specified in the 'accessibleFrom' option.
-      # As a failsafe, the 'dns-leak' chain drops any DNS traffic that falls through to the main table. This can happen if the WireGuard interface or the '51820' route is removed.
+      # Force all DNS traffic (port 53 TCP/UDP) through
+      # the WireGuard interface via policy routing.
+      #
+      # Traffic on port 53 uses a separate routing table ('51820')
+      # so it always exits through the WireGuard interface.
+      # This prevents DNS lookups from passing through the veth pair when the
+      # nameserver appears in the main routing table. This in practice means
+      # that DNS is not leaked when a nameserver is specified in
+      # the 'accessibleFrom' option. As a failsafe, the 'dns-leak' chain drops
+      # any DNS traffic that falls through to the main table. This can happen
+      # if the WireGuard interface or the '51820' route is removed.
 
       ip -n ${netnsName} route add default dev ${netnsName}0 table 51820
 


### PR DESCRIPTION
Services inside the netns should be accessible from the outside via the ip ranges given in the `accessibleFrom` option, but we never want to establish a new connection to these ranges from within the netns.

Currently, packets sent on a new connection via the veth from within the netns are lost when they reach the hosts default routing table. This happens because we do not use masquerading, so the packets will have the bridge address as the source, which the hosts default routing table does not have a rule for. This is of course just kind of lucky, so this PR adds rules to drop outgoing packets for new connections via the veth, to make sure the packets never even reaches the hosts default routing table.