### PR TITLE
feat: add allowedEgress option for tunnel-exempt destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ vpnNamespaces.<name> = { # The name is limited to 7 characters
   accessibleFrom = [
     "<ip or subnet>"
   ];
+  allowedEgress = [ # Destinations the namespace may reach outside the tunnel
+    "<ip or subnet>"
+  ];
   portMappings = [{
       from = <port on host>;
       to = <port in VPN network namespace>;

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -40,6 +40,28 @@ in {
       ];
     };
 
+    allowedEgress = mkOption {
+      type = listOf ipAddress;
+      default = [];
+      description = ''
+        Subnets, ranges, and specific addresses that the
+        namespace may initiate connections to outside the
+        VPN tunnel, e.g. a database or media server on the
+        host or LAN.
+
+        Traffic to these destinations is routed over the
+        veth pair instead of the tunnel, and is exempt from
+        the kill switch that drops new outgoing connections
+        via the veth. All other outgoing traffic still only
+        leaves through the tunnel.
+      '';
+      example = [
+        "10.0.2.15"
+        "192.168.1.0/24"
+        "fd25:9ab6:6133::203"
+      ];
+    };
+
     namespaceAddress = mkOption {
       type = ipv4;
       default = "192.168.15.1";

--- a/modules/vpn-down.nix
+++ b/modules/vpn-down.nix
@@ -39,5 +39,25 @@ pkgs.writeShellApplication {
     ${optionalIPv6String ''
       ip6tables -t nat -X ${netnsName}-prerouting
     ''}
+
+    # Delete postrouting rules
+    while read -r rule
+    do
+      # shellcheck disable=SC2086
+      iptables -t nat -D ''${rule#* }
+    done < <(iptables -t nat -S | awk '/${netnsName}-postrouting/ && !/-N/')
+
+    ${optionalIPv6String ''
+      while read -r rule
+      do
+        # shellcheck disable=SC2086
+        ip6tables -t nat -D ''${rule#* }
+      done < <(ip6tables -t nat -S | awk '/${netnsName}-postrouting/ && !/-N/')
+    ''}
+
+    iptables -t nat -X ${netnsName}-postrouting
+    ${optionalIPv6String ''
+      ip6tables -t nat -X ${netnsName}-postrouting
+    ''}
   '';
 }

--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -18,6 +18,8 @@
 
   utils = import ../lib/utils.nix {inherit lib;};
   inherit (utils) isValidIPv4;
+
+  routeDestinations = lib.unique (def.allowedEgress ++ def.accessibleFrom);
 in
   pkgs.writeShellApplication {
     name = "${netnsName}-up";
@@ -178,22 +180,36 @@ in
         ip -6 -n ${netnsName} route add default dev ${netnsName}0
       ''}
 
-      # Allow the namespace to initiate connections to specific
-      # destinations outside the tunnel (allowedEgress). Routed via the
-      # bridge, and accepted before the kill switch rules below so these
-      # destinations are exempt from the veth NEW drop. Routes use
-      # replace, not add, so a range appearing in both allowedEgress
-      # and accessibleFrom cannot fail the script.
+      # Routes for every destination reachable via the bridge, from both
+      # accessibleFrom and allowedEgress. Deduplicated so a range appearing
+      # in both lists cannot fail the script, while a genuinely conflicting
+      # route (a full range colliding with the tunnel default) still fails
+      # loudly instead of silently replacing it.
       ${concatMapStrings (
           x:
             if isValidIPv4 x
             then ''
-              ip -n ${netnsName} route replace ${x} via ${def.bridgeAddress}
+              ip -n ${netnsName} route add ${x} via ${def.bridgeAddress}
+            ''
+            else
+              optionalIPv6String ''
+                ip -n ${netnsName} route add ${x} via ${def.bridgeAddressIPv6}
+              ''
+        )
+        routeDestinations}
+
+      # Allow the namespace to initiate connections to specific
+      # destinations outside the tunnel (allowedEgress). Accepted before
+      # the kill switch rules below so these destinations are exempt from
+      # the veth NEW drop.
+      ${concatMapStrings (
+          x:
+            if isValidIPv4 x
+            then ''
               ip netns exec ${netnsName} iptables -A OUTPUT -o veth-${netnsName} -d ${x} -j ACCEPT
             ''
             else
               optionalIPv6String ''
-                ip -n ${netnsName} route replace ${x} via ${def.bridgeAddressIPv6}
                 ip netns exec ${netnsName} ip6tables -A OUTPUT -o veth-${netnsName} -d ${x} -j ACCEPT
               ''
         )
@@ -203,13 +219,11 @@ in
           x:
             if isValidIPv4 x
             then ''
-              ip -n ${netnsName} route replace ${x} via ${def.bridgeAddress}
               ip netns exec ${netnsName} iptables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
               ip netns exec ${netnsName} iptables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate NEW -j DROP
             ''
             else
               optionalIPv6String ''
-                ip -n ${netnsName} route replace ${x} via ${def.bridgeAddressIPv6}
                 ip netns exec ${netnsName} ip6tables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
                 ip netns exec ${netnsName} ip6tables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate NEW -j DROP
               ''
@@ -288,11 +302,11 @@ in
           x:
             if isValidIPv4 x
             then ''
-              iptables -t nat -A ${netnsName}-postrouting -s ${def.namespaceAddress}/24 -d ${x} -j MASQUERADE
+              iptables -t nat -A ${netnsName}-postrouting -s ${def.namespaceAddress} -d ${x} -j MASQUERADE
             ''
             else
               optionalIPv6String ''
-                ip6tables -t nat -A ${netnsName}-postrouting -s ${def.namespaceAddressIPv6}/64 -d ${x} -j MASQUERADE
+                ip6tables -t nat -A ${netnsName}-postrouting -s ${def.namespaceAddressIPv6} -d ${x} -j MASQUERADE
               ''
         )
         def.allowedEgress}

--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -178,6 +178,25 @@ in
         ip -6 -n ${netnsName} route add default dev ${netnsName}0
       ''}
 
+      # Allow the namespace to initiate connections to specific
+      # destinations outside the tunnel (allowedEgress). Routed via the
+      # bridge, and accepted before the kill switch rules below so these
+      # destinations are exempt from the veth NEW drop.
+      ${concatMapStrings (
+          x:
+            if isValidIPv4 x
+            then ''
+              ip -n ${netnsName} route add ${x} via ${def.bridgeAddress}
+              ip netns exec ${netnsName} iptables -A OUTPUT -o veth-${netnsName} -d ${x} -j ACCEPT
+            ''
+            else
+              optionalIPv6String ''
+                ip -n ${netnsName} route add ${x} via ${def.bridgeAddressIPv6}
+                ip netns exec ${netnsName} ip6tables -A OUTPUT -o veth-${netnsName} -d ${x} -j ACCEPT
+              ''
+        )
+        def.allowedEgress}
+
       ${concatMapStrings (
           x:
             if isValidIPv4 x

--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -181,17 +181,19 @@ in
       # Allow the namespace to initiate connections to specific
       # destinations outside the tunnel (allowedEgress). Routed via the
       # bridge, and accepted before the kill switch rules below so these
-      # destinations are exempt from the veth NEW drop.
+      # destinations are exempt from the veth NEW drop. Routes use
+      # replace, not add, so a range appearing in both allowedEgress
+      # and accessibleFrom cannot fail the script.
       ${concatMapStrings (
           x:
             if isValidIPv4 x
             then ''
-              ip -n ${netnsName} route add ${x} via ${def.bridgeAddress}
+              ip -n ${netnsName} route replace ${x} via ${def.bridgeAddress}
               ip netns exec ${netnsName} iptables -A OUTPUT -o veth-${netnsName} -d ${x} -j ACCEPT
             ''
             else
               optionalIPv6String ''
-                ip -n ${netnsName} route add ${x} via ${def.bridgeAddressIPv6}
+                ip -n ${netnsName} route replace ${x} via ${def.bridgeAddressIPv6}
                 ip netns exec ${netnsName} ip6tables -A OUTPUT -o veth-${netnsName} -d ${x} -j ACCEPT
               ''
         )
@@ -201,13 +203,13 @@ in
           x:
             if isValidIPv4 x
             then ''
-              ip -n ${netnsName} route add ${x} via ${def.bridgeAddress}
+              ip -n ${netnsName} route replace ${x} via ${def.bridgeAddress}
               ip netns exec ${netnsName} iptables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
               ip netns exec ${netnsName} iptables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate NEW -j DROP
             ''
             else
               optionalIPv6String ''
-                ip -n ${netnsName} route add ${x} via ${def.bridgeAddressIPv6}
+                ip -n ${netnsName} route replace ${x} via ${def.bridgeAddressIPv6}
                 ip netns exec ${netnsName} ip6tables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
                 ip netns exec ${netnsName} ip6tables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate NEW -j DROP
               ''
@@ -271,6 +273,29 @@ in
         generatePreroutingRules "${netnsName}-prerouting" def.namespaceAddress def.namespaceAddressIPv6
         def.portMappings
       }
+
+      # Masquerade namespace-initiated traffic to allowedEgress
+      # destinations. Replies from LAN machines beyond the host would
+      # otherwise target the private namespace address, which the LAN
+      # cannot route.
+      iptables -t nat -N ${netnsName}-postrouting
+      iptables -t nat -A POSTROUTING -j ${netnsName}-postrouting
+      ${optionalIPv6String ''
+        ip6tables -t nat -N ${netnsName}-postrouting
+        ip6tables -t nat -A POSTROUTING -j ${netnsName}-postrouting
+      ''}
+      ${concatMapStrings (
+          x:
+            if isValidIPv4 x
+            then ''
+              iptables -t nat -A ${netnsName}-postrouting -s ${def.namespaceAddress}/24 -d ${x} -j MASQUERADE
+            ''
+            else
+              optionalIPv6String ''
+                ip6tables -t nat -A ${netnsName}-postrouting -s ${def.namespaceAddressIPv6}/64 -d ${x} -j MASQUERADE
+              ''
+        )
+        def.allowedEgress}
 
       # Add veth INPUT rules
       ${generatePortMapRules netnsName "veth-${netnsName}" def.portMappings}

--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -289,9 +289,11 @@ in
       }
 
       # Masquerade namespace-initiated traffic to allowedEgress
-      # destinations. Replies from LAN machines beyond the host would
-      # otherwise target the private namespace address, which the LAN
-      # cannot route.
+      # destinations. Without this, packets leave the host with the
+      # private namespace source address. The destination either
+      # discards them on arrival (rp_filter, no route back to the
+      # source) or accepts them and fails to route its replies, so
+      # connections never complete regardless.
       iptables -t nat -N ${netnsName}-postrouting
       iptables -t nat -A POSTROUTING -j ${netnsName}-postrouting
       ${optionalIPv6String ''

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -31,11 +31,19 @@
           "fd25:9ab6:6133::/64"
           "::"
         ];
-        # deliberately outside the accessibleFrom subnets, so these prove
-        # allowedEgress installs its own routes
+        # 172.16.0.99 and fd25:9ab6:6134::99 are deliberately outside the
+        # accessibleFrom subnets, so they prove allowedEgress installs its
+        # own routes. 10.0.0.0/8 deliberately duplicates an accessibleFrom
+        # entry, so it proves the overlap cannot fail the start script.
         allowedEgress = [
           "172.16.0.99"
           "fd25:9ab6:6134::99"
+          "10.0.0.0/8"
+          # the test driver numbers every machine as 192.168.1.x on the
+          # shared vlan. fdc0:1::/64 is a static ULA assigned to eth1 on
+          # two machines below. both back the end-to-end LAN egress pings.
+          "192.168.1.0/24"
+          "fdc0:1::/64"
         ];
         # Test unconventional name for config file
         wireguardConfigFile = "/etc/wireguard/wireguardconfiguration.txt";
@@ -63,7 +71,19 @@
       config = lib.mkMerge (config ++ [base]);
     };
   in {
-    machine_dhcp = createNode [basicNetns];
+    machine_dhcp = createNode [
+      basicNetns
+      {
+        # static ULA on the test vlan, used as the masquerade source for
+        # the v6 LAN egress ping
+        networking.interfaces.eth1.ipv6.addresses = [
+          {
+            address = "fdc0:1::3";
+            prefixLength = 64;
+          }
+        ];
+      }
+    ];
 
     machine_networkd = createNode [
       basicNetns
@@ -72,6 +92,14 @@
         systemd.network.enable = true;
         networking.useDHCP = false;
         networking.dhcpcd.enable = false;
+
+        # target of the v6 LAN egress ping
+        networking.interfaces.eth1.ipv6.addresses = [
+          {
+            address = "fdc0:1::6";
+            prefixLength = 64;
+          }
+        ];
       }
     ];
 
@@ -159,6 +187,13 @@
     egress_rules_v6 = machine_dhcp.succeed("ip netns exec wg ip6tables -S OUTPUT")
     assert egress_rules_v6.index("-d fd25:9ab6:6134::99/128") < egress_rules_v6.index("--ctstate NEW -j DROP")
 
+    # allowedEgress masquerades namespace traffic on the host, so LAN
+    # machines beyond the host can route replies back
+    machine_dhcp.succeed(
+      "iptables -t nat -S wg-postrouting | grep -q -- '-d 172.16.0.99/32.*-j MASQUERADE'")
+    machine_dhcp.succeed(
+      "ip6tables -t nat -S wg-postrouting | grep -q -- '-d fd25:9ab6:6134::99/128.*-j MASQUERADE'")
+
     machine_networkd.wait_for_unit("wg.service")
 
     machine_networkd.succeed(
@@ -167,6 +202,18 @@
       '[ $(cat /sys/class/net/veth-wg-br/operstate) == "up" ]')
     machine_networkd.succeed(
       '[ $(ip netns exec wg cat /sys/class/net/veth-wg/operstate) == "up" ]')
+
+    # LAN egress, end to end: reach another machine on the test vlan from
+    # inside the netns. The peer has no route back to the namespace
+    # subnet, so replies only arrive if the host forwarded and
+    # masqueraded the traffic.
+    peer_v4 = machine_networkd.succeed(
+      "ip -4 -o addr show eth1 scope global | awk 'NR==1 {print $4}' | cut -d/ -f1"
+    ).strip()
+    machine_dhcp.wait_until_succeeds(
+      f"ip netns exec wg ping -c 1 -W 2 {peer_v4}", timeout=60)
+    machine_dhcp.wait_until_succeeds(
+      "ip netns exec wg ping -c 1 -W 2 fdc0:1::6", timeout=60)
 
     machine_max_name_length.wait_for_unit("vpnname.service")
 

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -31,6 +31,12 @@
           "fd25:9ab6:6133::/64"
           "::"
         ];
+        # deliberately outside the accessibleFrom subnets, so these prove
+        # allowedEgress installs its own routes
+        allowedEgress = [
+          "172.16.0.99"
+          "fd25:9ab6:6134::99"
+        ];
         # Test unconventional name for config file
         wireguardConfigFile = "/etc/wireguard/wireguardconfiguration.txt";
         portMappings = [
@@ -139,6 +145,19 @@
       '[ $(cat /sys/class/net/veth-wg-br/operstate) == "up" ]')
     machine_dhcp.succeed(
       '[ $(ip netns exec wg cat /sys/class/net/veth-wg/operstate) == "up" ]')
+
+    # allowedEgress installs a route via the bridge and an accept that
+    # precedes the veth NEW drop, for v4 and v6
+    machine_dhcp.succeed(
+      'ip netns exec wg ip route get 172.16.0.99 | grep -q "via 192.168.15.5"')
+    machine_dhcp.succeed(
+      'ip netns exec wg ip route get fd25:9ab6:6134::99 | grep -q "via fd93:9701:1d00::1"')
+
+    egress_rules = machine_dhcp.succeed("ip netns exec wg iptables -S OUTPUT")
+    assert egress_rules.index("-d 172.16.0.99/32") < egress_rules.index("--ctstate NEW -j DROP")
+
+    egress_rules_v6 = machine_dhcp.succeed("ip netns exec wg ip6tables -S OUTPUT")
+    assert egress_rules_v6.index("-d fd25:9ab6:6134::99/128") < egress_rules_v6.index("--ctstate NEW -j DROP")
 
     machine_networkd.wait_for_unit("wg.service")
 


### PR DESCRIPTION
#47 made the namespace drop new outgoing connections via the veth. That is the right default, but it also broke setups where a confined service has a dependency outside the tunnel: a database on the host or LAN, a host-side download client, and so on. #41 was exactly this ask, and its workaround (a manual `iptables -I OUTPUT ... -j ACCEPT` in the namespace) stopped working when #47 landed.

This adds `allowedEgress`, the outbound counterpart of `accessibleFrom`:

```nix
vpnNamespaces.wg = {
  # ...
  allowedEgress = [
    "10.0.0.5"
    "192.168.1.0/24"
  ];
};
```

Each entry gets a route via the bridge and an accept on the veth ahead of the kill switch drop, for both v4 and v6. Everything else still only leaves through the tunnel. Entries are explicit opt-outs, so the trust model matches `accessibleFrom`.

The option installs its own routes, so a destination does not have to fall inside an `accessibleFrom` subnet to be reachable.

Test coverage added: route installation is asserted with destinations deliberately outside the `accessibleFrom` subnets, and rule order is asserted relative to the NEW drop, v4 and v6. The full test suite passes.
