### PR TITLE
refactor: rename accessibleFrom -> allowedIngress

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 <div align="center" id="user-content-toc">
   <ul style="list-style: none;">
     <summary>
@@ -48,7 +46,7 @@
 vpnNamespaces.<name> = { # The name is limited to 7 characters
   enable = true;
   wireguardConfigFile = <path to secret wireguard config file>;
-  accessibleFrom = [
+  allowedIngress = [
     "<ip or subnet>"
   ];
   allowedEgress = [ # Destinations the namespace may reach outside the tunnel
@@ -85,7 +83,7 @@ systemd.services.<name>.vpnConfinement = {
   vpnNamespaces.wg = {
     enable = true;
     wireguardConfigFile = /. + "/secrets/wg0.conf";
-    accessibleFrom = [
+    allowedIngress = [
       "192.168.0.0/24"
     ];
     portMappings = [

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -10,6 +10,10 @@
     enum
     ;
 in {
+  imports = [
+    (lib.mkRenamedOptionModule ["accessibleFrom"] ["allowedIngress"])
+  ];
+
   options = {
     enable =
       mkEnableOption "vpn netns"
@@ -25,7 +29,7 @@ in {
         '';
       };
 
-    accessibleFrom = mkOption {
+    allowedIngress = mkOption {
       type = listOf ipAddress;
       default = [];
       description = ''

--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -19,7 +19,7 @@
   utils = import ../lib/utils.nix {inherit lib;};
   inherit (utils) isValidIPv4;
 
-  routeDestinations = lib.unique (def.allowedEgress ++ def.accessibleFrom);
+  routeDestinations = lib.unique (def.allowedEgress ++ def.allowedIngress);
 in
   pkgs.writeShellApplication {
     name = "${netnsName}-up";
@@ -181,7 +181,7 @@ in
       ''}
 
       # Routes for every destination reachable via the bridge, from both
-      # accessibleFrom and allowedEgress. Deduplicated so a range appearing
+      # allowedIngress and allowedEgress. Deduplicated so a range appearing
       # in both lists cannot fail the script, while a genuinely conflicting
       # route (a full range colliding with the tunnel default) still fails
       # loudly instead of silently replacing it.
@@ -228,7 +228,7 @@ in
                 ip netns exec ${netnsName} ip6tables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate NEW -j DROP
               ''
         )
-        def.accessibleFrom}
+        def.allowedIngress}
 
       # Force all DNS traffic (port 53 TCP/UDP) through
       # the WireGuard interface via policy routing.
@@ -238,7 +238,7 @@ in
       # This prevents DNS lookups from passing through the veth pair when the
       # nameserver appears in the main routing table. This in practice means
       # that DNS is not leaked when a nameserver is specified in
-      # the 'accessibleFrom' option. As a failsafe, the 'dns-leak' chain drops
+      # the 'allowedIngress' option. As a failsafe, the 'dns-leak' chain drops
       # any DNS traffic that falls through to the main table. This can happen
       # if the WireGuard interface or the '51820' route is removed.
 

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -24,7 +24,7 @@
     basicNetns = {
       vpnNamespaces.wg = {
         enable = true;
-        accessibleFrom = [
+        allowedIngress = [
           "192.168.0.0/24"
           "10.0.0.0/8"
           "127.0.0.1"
@@ -32,8 +32,8 @@
           "::"
         ];
         # 172.16.0.99 and fd25:9ab6:6134::99 are deliberately outside the
-        # accessibleFrom subnets, so they prove allowedEgress installs its
-        # own routes. 10.0.0.0/8 deliberately duplicates an accessibleFrom
+        # allowedIngress subnets, so they prove allowedEgress installs its
+        # own routes. 10.0.0.0/8 deliberately duplicates an allowedIngress
         # entry, so it proves the overlap cannot fail the start script.
         allowedEgress = [
           "172.16.0.99"
@@ -117,6 +117,18 @@
         vpnNamespaces.vpn-nam = {
           enable = true;
           wireguardConfigFile = "/etc/wireguard/wg0.conf";
+        };
+      }
+    ];
+
+    machine_renamed_option = createNode [
+      {
+        vpnNamespaces.wg = {
+          enable = true;
+          wireguardConfigFile = "/etc/wireguard/wg0.conf";
+          # deliberately uses the pre-rename option name, so this machine
+          # proves the mkRenamedOptionModule alias keeps old configs working
+          accessibleFrom = ["192.168.0.0/24"];
         };
       }
     ];
@@ -226,6 +238,10 @@
         cat /sys/class/net/veth-vpnname/operstate) == "up" ]')
 
     machine_dash_in_name.wait_for_unit("vpn-nam.service")
+
+    machine_renamed_option.wait_for_unit("wg.service")
+    machine_renamed_option.succeed(
+      'ip netns exec wg ip route get 192.168.0.1 | grep -q "via 192.168.15.5"')
 
     machine_dash_in_name.succeed(
       '[ $(cat /sys/class/net/vpn-nam-br/operstate) == "up" ]')


### PR DESCRIPTION
Follow-up from #48

`accessibleFrom` -> `allowedIngress` so the pair is symmetric with `allowedEgress` and both carry their direction. Old configs keep working via `mkRenamedOptionModule`, with a test machine using the old name.

You mentioned wanting to rename `openVPNPorts` too, we can discuss both the semantics of that and allowedIngress/egress  here