### PR TITLE
fix: prevent `bridgeAddress` from being used in route destinations

### DIFF
--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -19,7 +19,9 @@
   utils = import ../lib/utils.nix {inherit lib;};
   inherit (utils) isValidIPv4;
 
-  routeDestinations = lib.unique (def.allowedEgress ++ def.accessibleFrom);
+  routeDestinations = builtins.filter
+    (x: x != def.bridgeAddress && x != def.bridgeAddressIPv6)
+    (lib.unique (def.allowedEgress ++ def.accessibleFrom));
 in
   pkgs.writeShellApplication {
     name = "${netnsName}-up";

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -44,6 +44,11 @@
           # two machines below. both back the end-to-end LAN egress pings.
           "192.168.1.0/24"
           "fdc0:1::/64"
+          # Including the bridge addresses (default values) to prove
+          # they do not produce self-referential routes that poison
+          # other resolutions, but also allow for routing back to the host.
+          "192.168.15.5"
+          "fd93:9701:1d00::1"
         ];
         # Test unconventional name for config file
         wireguardConfigFile = "/etc/wireguard/wireguardconfiguration.txt";
@@ -180,6 +185,14 @@
       'ip netns exec wg ip route get 172.16.0.99 | grep -q "via 192.168.15.5"')
     machine_dhcp.succeed(
       'ip netns exec wg ip route get fd25:9ab6:6134::99 | grep -q "via fd93:9701:1d00::1"')
+
+    # Bridge addresses should not exist in the routing table, they are
+    # inherently reachable via veth. A self-referential ipv6 route would prevent
+    # other ipv6 routes from being routable.
+    machine_dhcp.fail(
+      'ip netns exec wg ip -6 route show fd93:9701:1d00::1 | grep -q "fd93:9701:1d00::1 via fd93:9701:1d00::1"')
+    machine_dhcp.fail(
+      'ip netns exec wg ip route show 192.168.15.5 | grep -q "192.168.15.5 via 192.168.15.5"')
 
     egress_rules = machine_dhcp.succeed("ip netns exec wg iptables -S OUTPUT")
     assert egress_rules.index("-d 172.16.0.99/32") < egress_rules.index("--ctstate NEW -j DROP")


### PR DESCRIPTION
Using `bridgeAddressIPv6` inside the `allowedEgress` causes there to be a self-referential route that causes any following ipv6 addresses to have the error `RTNETLINK answers: No route to host` which prevents the service from starting.
This issue doesn't affect the ipv4 routes, but does for ipv6 as from reading it appears that the routing is preferring the highest prefix match which is causing the `bridgeAddress` to be used instead of veth route as the gateway for the namespace.

These values are required in order to allow for traffic to get between the namespaces from the iptable rules, but are not required to be present in the ip routing configuration (https://github.com/Maroka-chan/VPN-Confinement/blob/master/modules/vpn-up.nix#L22) from my testing.

This could just be bad config or my poor understanding of the impacts each setting makes behind the scenes, so open to any suggestions or corrections.

A bad routing table (pre-change) - Missing all `wg2` addresses as the service fails to start, only contains the `wg.bridgeAddress` values:
```bash
$ sudo ip netns exec wg ip -6 route show
fd7d:76ee:e68f:a993:861f:144d:faac:e056 dev wg0 proto kernel metric 256 pref medium
fd93:9701:1d00::1 via fd93:9701:1d00::1 dev veth-wg metric 1024 pref medium
fd93:9701:1d00::/64 dev veth-wg proto kernel metric 256 pref medium
fe80::/64 dev veth-wg proto kernel metric 256 pref medium
default dev wg0 metric 1024 pref medium
```
A good routing table (post-change):
```bash
$ sudo ip netns exec wg ip -6 route show
fd7d:76ee:e68f:a993:861f:144d:faac:e056 dev wg0 proto kernel metric 256 pref medium
fd93:9701:1d00::/64 dev veth-wg proto kernel metric 256 pref medium
fe80::/64 dev veth-wg proto kernel metric 256 pref medium
default dev wg0 metric 1024 pref medium
```

--- 

Minimal reproducible config:

```nix
vpnNamespaces = rec {
    wg = {
      enable = true;
      accessibleFrom = [
        "127.0.0.0/24" # Allow connections from localhost (ipv4)
        wg2.namespaceAddress # Allow wg2 to access this namepace (ipv4)
        wg2.namespaceAddressIPv6 # Allow wg2 to access this namepace (ipv6)
      ];
      allowedEgress = [
        wg.bridgeAddress # Allow wg to use the bridge address back to localhost (ipv4)
        wg.bridgeAddressIPv6 # Allow wg to use the bridge address back to localhost (ipv6)
        wg2.namespaceAddress # Allow wg to connect to wg2 (ipv4)
        wg2.namespaceAddressIPv6 # Allow wg to connect to wg2 (ipv6)
      ];
      namespaceAddress = "192.168.15.1";
      namespaceAddressIPv6 = "fd93:9701:1d00::2";
      bridgeAddress = "192.168.15.5";
      bridgeAddressIPv6 = "fd93:9701:1d00::1";
    };
   wg2 = {
      enable = true;
      accessibleFrom = [
        "127.0.0.0/24"  # Allow connections from localhost (ipv4)
        wg.namespaceAddress  # Allow wg to access this namepace (ipv4)
        wg.namespaceAddressIPv6 # Allow wg to access this namepace (ipv6)
      ];
      allowedEgress = [
        wg2.bridgeAddress # Allow wg2 to use the bridge address back to localhost (ipv4)
        wg2.bridgeAddressIPv6 # Allow wg2 to use the bridge address back to localhost (ipv6)
        wg.namespaceAddress # Allow wg2 to connect to wg (ipv4)
        wg.namespaceAddressIPv6 # Allow wg2 to connect to wg (ipv6)
      ];
      namespaceAddress = "192.168.16.1";
      namespaceAddressIPv6 = "fd93:9801:1d00::2";
      bridgeAddress = "192.168.16.5";
      bridgeAddressIPv6 = "fd93:9801:1d00::1";
    };
};
```
