### PR TITLE
fix: ensure all egress kill switches are created regardless of accessibleFrom entries

### DIFF
--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -215,20 +215,11 @@ in
         )
         def.allowedEgress}
 
-      ${concatMapStrings (
-          x:
-            if isValidIPv4 x
-            then ''
-              ip netns exec ${netnsName} iptables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-              ip netns exec ${netnsName} iptables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate NEW -j DROP
-            ''
-            else
-              optionalIPv6String ''
-                ip netns exec ${netnsName} ip6tables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-                ip netns exec ${netnsName} ip6tables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate NEW -j DROP
-              ''
-        )
-        def.accessibleFrom}
+      # Kill switch: only replies may leave via the veth (except allowedEgress)
+      ${addNetNSIPRules netnsName [
+        "-A OUTPUT -o veth-${netnsName} -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT"
+        "-A OUTPUT -o veth-${netnsName} -m conntrack --ctstate NEW -j DROP"
+      ]}
 
       # Force all DNS traffic (port 53 TCP/UDP) through
       # the WireGuard interface via policy routing.


### PR DESCRIPTION
### Why
The egress kill switch is unintentionally created once per entry in `accessibleFrom`, and only either the ipv4 or ipv6 rule is created per entry. This makes it possible to end up with only the ipv4 kill switch or only the ipv6 one. It also means that the kill switch is not created at all if there are no entries.

### What
This PR makes the creation of the kill switch independent of the `accessibleFrom` entries, and it uses `addNetNSIPRules` to make sure the rules are created for both ipv4 and ipv6.
