### PR TITLE
feat: cli vpn-tunnel wrapper

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,24 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784856561,
+        "narHash": "sha256-/HjbyQqfFs3cG7o/zJ25RPaLZqS9a88z6vOGhMoZwRs=",
+        "rev": "597283ad8aa0b331c788e97c4c262d58877074ef",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/26.05/nixos-26.05.5984.597283ad8aa0/nixexprs.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,20 @@
 {
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz";
+
   outputs = inputs: {
+    overlays.default = final: prev: {
+      vpntunnel = inputs.self.packages.${final.system}.default;
+    };
+
     nixosModules = rec {
-      vpnConfinement = ./modules/vpn-netns.nix;
+      vpnConfinement = {
+        imports = [./modules/vpn-netns.nix];
+        nixpkgs.overlays = [inputs.self.overlays.default];
+      };
       default = vpnConfinement;
     };
+
+    packages.x86_64-linux.default =
+      inputs.nixpkgs.legacyPackages.x86_64-linux.callPackage ./pkgs/vpn-tunnel.nix {};
   };
 }

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -51,10 +51,12 @@ in {
                 InaccessiblePaths = [
                   "/run/nscd"
                   "/run/resolvconf"
+                  "/run/systemd/resolve"
                 ];
 
                 BindReadOnlyPaths = [
                   "/etc/netns/${vpn}/resolv.conf:/etc/resolv.conf:norbind"
+                  "/etc/netns/${vpn}/nsswitch.conf:/etc/nsswitch.conf:norbind"
                 ];
               };
             };

--- a/modules/vpn-netns.nix
+++ b/modules/vpn-netns.nix
@@ -43,7 +43,7 @@
       };
     };
 in {
-  imports = [./systemd.nix] ++ [(mkRenamedOptionModule ["vpnnamespaces"] ["vpnNamespaces"])];
+  imports = [./systemd.nix ./vpn-tunnel.nix] ++ [(mkRenamedOptionModule ["vpnnamespaces"] ["vpnNamespaces"])];
 
   options.vpnNamespaces = mkOption {
     type = attrsOf (submodule [(import ./options.nix)]);

--- a/modules/vpn-tunnel.nix
+++ b/modules/vpn-tunnel.nix
@@ -3,44 +3,7 @@
   lib,
   pkgs,
   ...
-}: let
-  # glibc definitions of insecure environment variables
-  #
-  # We extract the single header file we need into its own derivation,
-  # so that we don't have to pull full glibc sources to build wrappers.
-  #
-  # They're taken from pkgs.glibc so that we don't have to keep as close
-  # an eye on glibc changes. Not every relevant variable is in this header,
-  # so we maintain a slightly stricter list in wrapper.c itself as well.
-  unsecvars = lib.overrideDerivation (pkgs.srcOnly pkgs.glibc) (
-    {name, ...}: {
-      name = "${name}-unsecvars";
-      installPhase = ''
-        mkdir $out
-        cp sysdeps/generic/unsecvars.h $out
-      '';
-    }
-  );
-
-  vpntunnel = pkgs.callPackage ({
-    stdenv,
-    libcap,
-  }:
-    stdenv.mkDerivation {
-      pname = "vpntunnel";
-      version = "0.1.0";
-      src = ./vpntunnel.c;
-      dontUnpack = true;
-      nativeBuildInputs = [libcap.dev];
-      CFLAGS = ["-lcap" "-O2" "-Wall"];
-      buildPhase = ''
-        $CC $CFLAGS $src -I${unsecvars} -o vpntunnel
-      '';
-      installPhase = ''
-        install -Dm755 vpntunnel $out/bin/vpntunnel
-      '';
-    }) {};
-in {
+}: {
   options.programs.vpntunnel.enable = lib.mkEnableOption "vpntunnel";
 
   config = lib.mkIf config.programs.vpntunnel.enable {
@@ -76,7 +39,7 @@ in {
         rm -f "${wrapperDir}/vpntunnel"
 
         # Copy vpntunnel binary
-        cp ${vpntunnel}/bin/vpntunnel "${wrapperDir}/vpntunnel"
+        cp ${pkgs.vpntunnel}/bin/vpntunnel "${wrapperDir}/vpntunnel"
 
         # Prevent races
         chmod 0000 "${wrapperDir}/vpntunnel"

--- a/modules/vpn-tunnel.nix
+++ b/modules/vpn-tunnel.nix
@@ -1,0 +1,36 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  vpntunnel = pkgs.callPackage ({
+    stdenv,
+    libcap,
+  }:
+    stdenv.mkDerivation {
+      pname = "vpntunnel";
+      version = "0.1.0";
+      src = ./vpntunnel.c;
+      dontUnpack = true;
+      nativeBuildInputs = [libcap.dev];
+      buildPhase = ''
+        gcc -o vpntunnel $src -lcap -O2 -Wall
+      '';
+      installPhase = ''
+        install -Dm755 vpntunnel $out/bin/vpntunnel
+      '';
+    }) {};
+in {
+  options.programs.vpntunnel.enable = lib.mkEnableOption "vpntunnel";
+
+  config = lib.mkIf config.programs.vpntunnel.enable {
+    environment.systemPackages = [vpntunnel];
+    security.wrappers.vpntunnel = {
+      owner = "root";
+      group = "root";
+      source = "${lib.getExe vpntunnel}";
+      capabilities = "cap_sys_admin,cap_net_raw+ep";
+    };
+  };
+}

--- a/modules/vpn-tunnel.nix
+++ b/modules/vpn-tunnel.nix
@@ -4,6 +4,24 @@
   pkgs,
   ...
 }: let
+  # glibc definitions of insecure environment variables
+  #
+  # We extract the single header file we need into its own derivation,
+  # so that we don't have to pull full glibc sources to build wrappers.
+  #
+  # They're taken from pkgs.glibc so that we don't have to keep as close
+  # an eye on glibc changes. Not every relevant variable is in this header,
+  # so we maintain a slightly stricter list in wrapper.c itself as well.
+  unsecvars = lib.overrideDerivation (pkgs.srcOnly pkgs.glibc) (
+    {name, ...}: {
+      name = "${name}-unsecvars";
+      installPhase = ''
+        mkdir $out
+        cp sysdeps/generic/unsecvars.h $out
+      '';
+    }
+  );
+
   vpntunnel = pkgs.callPackage ({
     stdenv,
     libcap,
@@ -14,8 +32,9 @@
       src = ./vpntunnel.c;
       dontUnpack = true;
       nativeBuildInputs = [libcap.dev];
+      CFLAGS = ["-lcap" "-O2" "-Wall"];
       buildPhase = ''
-        gcc -o vpntunnel $src -lcap -O2 -Wall
+        $CC $CFLAGS $src -I${unsecvars} -o vpntunnel
       '';
       installPhase = ''
         install -Dm755 vpntunnel $out/bin/vpntunnel
@@ -25,12 +44,50 @@ in {
   options.programs.vpntunnel.enable = lib.mkEnableOption "vpntunnel";
 
   config = lib.mkIf config.programs.vpntunnel.enable {
-    environment.systemPackages = [vpntunnel];
-    security.wrappers.vpntunnel = {
-      owner = "root";
-      group = "root";
-      source = "${lib.getExe vpntunnel}";
-      capabilities = "cap_sys_admin,cap_net_raw+ep";
+    systemd.services.vpntunnel-wrapper = let
+      wrapperDir = config.security.wrapperDir;
+    in {
+      description = "Install vpntunnel with capabilities";
+
+      wantedBy = ["sysinit.target"];
+      partOf = ["suid-sgid-wrappers.service"];
+      after = ["suid-sgid-wrappers.service"];
+      before = ["sysinit.target" "shutdown.target"];
+      conflicts = ["shutdown.target"];
+
+      unitConfig = {
+        DefaultDependencies = false;
+        RequiresMountsFor = [
+          "/nix/store"
+          "/run/wrappers"
+        ];
+      };
+
+      serviceConfig.Type = "oneshot";
+
+      script = ''
+        # Ensure wrapper directory exists (created by suid-sgid-wrappers)
+        if [ ! -d "${wrapperDir}" ]; then
+          echo "Error: ${wrapperDir} does not exist"
+          exit 1
+        fi
+
+        # Remove old version if exists (for updates)
+        rm -f "${wrapperDir}/vpntunnel"
+
+        # Copy vpntunnel binary
+        cp ${vpntunnel}/bin/vpntunnel "${wrapperDir}/vpntunnel"
+
+        # Prevent races
+        chmod 0000 "${wrapperDir}/vpntunnel"
+        chown root:root "${wrapperDir}/vpntunnel"
+
+        # Set capabilities WITHOUT cap_setpcap (no ambient conversion)
+        ${pkgs.libcap}/bin/setcap cap_sys_admin+ep "${wrapperDir}/vpntunnel"
+
+        # Set executable permissions
+        chmod 0511 "${wrapperDir}/vpntunnel"
+      '';
     };
   };
 }

--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -71,13 +71,20 @@ in
         ip -n ${netnsName} address add "$addr" dev ${netnsName}0
       done
 
-      # Add DNS
+      # Clean up old netns config files
       rm -rf /etc/netns/${netnsName}
       mkdir -p /etc/netns/${netnsName}
+
+      # Generate resolv.conf
       IFS=","
       # shellcheck disable=SC2154
       for ns in $DNS; do
-        echo "nameserver $ns" >> /etc/netns/${netnsName}/resolv.conf
+        echo "nameserver $ns"
+      done > /etc/netns/${netnsName}/resolv.conf
+
+      # Setup DNS firewall rules
+      IFS=","
+      for ns in $DNS; do
         if [[ $ns == *"."* ]]; then
           ip netns exec ${netnsName} iptables \
             -I dns-fw -p udp -d "$ns" -j ACCEPT
@@ -89,9 +96,17 @@ in
         fi
       done
 
-      # Add nsswitch config
-      echo "hosts: files dns" > /etc/netns/${netnsName}/nsswitch.conf
-      echo "networks: files" >> /etc/netns/${netnsName}/nsswitch.conf
+      # Generate nsswitch config
+      cat > /etc/netns/${netnsName}/nsswitch.conf << EOF
+      hosts: files dns
+      networks: files
+      EOF
+
+      # Generate hosts file
+      cat > /etc/netns/${netnsName}/hosts << EOF
+      127.0.0.1 localhost
+      ::1 localhost
+      EOF
 
       # Strips the config of wg-quick settings
       shopt -s extglob

--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -187,17 +187,29 @@ in
             if isValidIPv4 x
             then ''
               ip -n ${netnsName} route add ${x} via ${def.bridgeAddress}
+              ip netns exec ${netnsName} iptables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+              ip netns exec ${netnsName} iptables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate NEW -j DROP
             ''
             else
               optionalIPv6String ''
                 ip -n ${netnsName} route add ${x} via ${def.bridgeAddressIPv6}
+                ip netns exec ${netnsName} ip6tables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+                ip netns exec ${netnsName} ip6tables -A OUTPUT -o veth-${netnsName} -m conntrack --ctstate NEW -j DROP
               ''
         )
         def.accessibleFrom}
 
-      # Force all DNS traffic (port 53 TCP/UDP) through the WireGuard interface via policy routing.
-      # Traffic on port 53 uses a separate routing table ('51820') so it always exits through the WireGuard interface. This prevents DNS lookups from passing through the veth pair when the nameserver appears in the main routing table. This in practice means that DNS is not leaked when a nameserver is specified in the 'accessibleFrom' option.
-      # As a failsafe, the 'dns-leak' chain drops any DNS traffic that falls through to the main table. This can happen if the WireGuard interface or the '51820' route is removed.
+      # Force all DNS traffic (port 53 TCP/UDP) through
+      # the WireGuard interface via policy routing.
+      #
+      # Traffic on port 53 uses a separate routing table ('51820')
+      # so it always exits through the WireGuard interface.
+      # This prevents DNS lookups from passing through the veth pair when the
+      # nameserver appears in the main routing table. This in practice means
+      # that DNS is not leaked when a nameserver is specified in
+      # the 'accessibleFrom' option. As a failsafe, the 'dns-leak' chain drops
+      # any DNS traffic that falls through to the main table. This can happen
+      # if the WireGuard interface or the '51820' route is removed.
 
       ip -n ${netnsName} route add default dev ${netnsName}0 table 51820
 

--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -195,6 +195,44 @@ in
         )
         def.accessibleFrom}
 
+      # Force all DNS traffic (port 53 TCP/UDP) through the WireGuard interface via policy routing.
+      # Traffic on port 53 uses a separate routing table ('51820') so it always exits through the WireGuard interface. This prevents DNS lookups from passing through the veth pair when the nameserver appears in the main routing table. This in practice means that DNS is not leaked when a nameserver is specified in the 'accessibleFrom' option.
+      # As a failsafe, the 'dns-leak' chain drops any DNS traffic that falls through to the main table. This can happen if the WireGuard interface or the '51820' route is removed.
+
+      ip -n ${netnsName} route add default dev ${netnsName}0 table 51820
+
+      ip -n ${netnsName} rule add ipproto udp dport 53 lookup 51820 priority 100
+      ip -n ${netnsName} rule add ipproto tcp dport 53 lookup 51820 priority 100
+
+      # Guard against DNS leaks when routing table ('51820') is not present.
+      # Monitor dropped packets with:
+      #   sudo ip netns exec ${netnsName} iptables -L dns-leak -v -n
+      ip netns exec ${netnsName} iptables -N dns-leak
+
+      ip netns exec ${netnsName} iptables -A dns-leak \
+        -m limit --limit 1/min -j LOG --log-prefix "dns-leak: "
+      ip netns exec ${netnsName} iptables -A dns-leak -j DROP
+
+      ip netns exec ${netnsName} iptables -I OUTPUT 1 -o veth-${netnsName} \
+        -p udp --dport 53 -j dns-leak
+      ip netns exec ${netnsName} iptables -I OUTPUT 1 -o veth-${netnsName} \
+        -p tcp --dport 53 -j dns-leak
+
+      ${optionalIPv6String ''
+        ip -6 -n ${netnsName} route add default dev ${netnsName}0 table 51820
+        ip -6 -n ${netnsName} rule add ipproto udp dport 53 lookup 51820 priority 100
+        ip -6 -n ${netnsName} rule add ipproto tcp dport 53 lookup 51820 priority 100
+
+        ip netns exec ${netnsName} ip6tables -N dns-leak
+        ip netns exec ${netnsName} ip6tables -A dns-leak \
+          -m limit --limit 1/min -j LOG --log-prefix "dns-leak6: "
+        ip netns exec ${netnsName} ip6tables -A dns-leak -j DROP
+        ip netns exec ${netnsName} ip6tables -I OUTPUT 1 -o veth-${netnsName} \
+          -p udp --dport 53 -j dns-leak
+        ip netns exec ${netnsName} ip6tables -I OUTPUT 1 -o veth-${netnsName} \
+          -p tcp --dport 53 -j dns-leak
+      ''}
+
       # Add prerouting rules
       iptables -t nat -N ${netnsName}-prerouting
       iptables -t nat -A PREROUTING -j ${netnsName}-prerouting

--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -23,6 +23,7 @@ in
     name = "${netnsName}-up";
     runtimeInputs = with pkgs; [
       bash
+      sysctl
       iproute2
       iptables
       unixtools.ping
@@ -277,5 +278,9 @@ in
 
       # Add VPN INPUT rules
       ${generateAllowedPortRules netnsName "${netnsName}0" def.openVPNPorts}
+
+      # Allow unprivileged ICMP sockets.
+      # This is the default on the host, so we just match it to make ping work.
+      ip netns exec ${netnsName} sysctl -w net.ipv4.ping_group_range="0 2147483647"
     '';
   }

--- a/modules/vpn-up.nix
+++ b/modules/vpn-up.nix
@@ -89,6 +89,10 @@ in
         fi
       done
 
+      # Add nsswitch config
+      echo "hosts: files dns" > /etc/netns/${netnsName}/nsswitch.conf
+      echo "networks: files" >> /etc/netns/${netnsName}/nsswitch.conf
+
       # Strips the config of wg-quick settings
       shopt -s extglob
       strip_wgquick_config() {

--- a/modules/vpntunnel.c
+++ b/modules/vpntunnel.c
@@ -28,6 +28,7 @@ static int do_mount(const char *src, const char *dst, const char *type, unsigned
 
 static void mask_path_if_exists(const char *path) {
     struct stat st;
+
     if (stat(path, &st) == 0) {
         // Path exists, so mount MUST succeed
         if (S_ISDIR(st.st_mode)) {
@@ -124,6 +125,16 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
+    // DNS leak prevention by masking system DNS service paths.
+    // Similar to systemd InaccessiblePaths, but more robust: MS_PRIVATE
+    // ensures these paths cannot become accessible even if the host adds
+    // or removes mounts after we enter the namespace.
+    mask_path_if_exists("/run/nscd");
+    mask_path_if_exists("/run/resolvconf");
+    mask_path_if_exists("/run/systemd/resolve/io.systemd.Resolve");
+    mask_path_if_exists("/run/systemd/resolve/stub-resolv.conf");
+    mask_path_if_exists("/run/systemd/resolve/resolv.conf");
+
     // Bind-mount netns-specific files (same as ip netns exec does).
     // More strict because we exit the program if any of the files are not
     // present, as we require them for configuring DNS and preventing leaks.
@@ -143,16 +154,6 @@ int main(int argc, char *argv[]) {
     if (do_mount(buf, "/etc/hosts", NULL, MS_BIND) != 0) {
         return 1;
     }
-
-    // DNS leak prevention by masking system DNS service paths.
-    // Similar to systemd InaccessiblePaths, but more robust: MS_PRIVATE
-    // ensures these paths cannot become accessible even if the host adds
-    // or removes mounts after we enter the namespace.
-    mask_path_if_exists("/run/nscd");
-    mask_path_if_exists("/run/resolvconf");
-    mask_path_if_exists("/run/systemd/resolve/io.systemd.Resolve");
-    mask_path_if_exists("/run/systemd/resolve/stub-resolv.conf");
-    mask_path_if_exists("/run/systemd/resolve/resolv.conf");
 
     // Drop all capabilities before exec
     drop_privileges();

--- a/modules/vpntunnel.c
+++ b/modules/vpntunnel.c
@@ -134,6 +134,13 @@ int main(int argc, char *argv[]) {
     mask_path_if_exists("/run/systemd/resolve/io.systemd.Resolve");
     mask_path_if_exists("/run/systemd/resolve/stub-resolv.conf");
     mask_path_if_exists("/run/systemd/resolve/resolv.conf");
+    mask_path_if_exists("/run/systemd/resolve/netif");
+    // mDNS can leak local network queries
+    mask_path_if_exists("/run/avahi-daemon");
+    mask_path_if_exists("/var/run/avahi-daemon");
+    // If you use LDAP/enterprise authentication
+    mask_path_if_exists("/var/run/nslcd");
+    mask_path_if_exists("/var/run/sssd");
 
     // Bind-mount netns-specific files (same as ip netns exec does).
     // More strict because we exit the program if any of the files are not

--- a/modules/vpntunnel.c
+++ b/modules/vpntunnel.c
@@ -5,11 +5,25 @@
 #include <unistd.h>
 #include <sched.h>
 #include <sys/mount.h>
+#include <sys/prctl.h>
 #include <sys/stat.h>
 #include <sys/capability.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <net/if.h>
+#include <linux/capability.h>
+
+#include <unsecvars.h>
+
+#define UNSECURE_ENVVARS_TUNABLES \
+  "MALLOC_CHECK_\0" \
+  "MALLOC_TOP_PAD_\0" \
+  "MALLOC_PERTURB_\0" \
+  "MALLOC_MMAP_THRESHOLD_\0" \
+  "MALLOC_TRIM_THRESHOLD_\0" \
+  "MALLOC_MMAP_MAX_\0" \
+  "MALLOC_ARENA_MAX\0" \
+  "MALLOC_ARENA_TEST\0"
 
 #define NETNS_DIR "/var/run/netns"
 #define NETNS_CONF_DIR "/etc/netns"
@@ -55,18 +69,35 @@ static void mask_path_if_exists(const char *path) {
 }
 
 static void drop_privileges(void) {
-    // Drop all capabilities before exec.
-    // This makes the target program run completely unprivileged inside the namespace.
-    // If specific capabilities are needed (e.g., CAP_NET_BIND_SERVICE),
-    // set them on the target binary with: setcap cap_name+ep /path/to/binary,
-    // or with the securityWrappers option on NixOS.
+    // Get current ambient capabilities
+    cap_value_t ambient_caps[CAP_LAST_CAP + 1];
+    int ambient_count = 0;
+
+    for (int i = 0; i <= CAP_LAST_CAP; i++) {
+        if (prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_IS_SET, i, 0, 0) == 1) {
+            ambient_caps[ambient_count++] = i;
+        }
+    }
+
+    // Set capabilities to only what was ambient (explicitly granted)
     cap_t caps = cap_get_proc();
     if (caps == NULL) {
         perror("cap_get_proc");
         exit(1);
     }
 
-    cap_clear(caps);  // Clear all capabilities - completely unprivileged
+    // Clear only permitted, effective, inheritable (NOT bounding set)
+    cap_clear_flag(caps, CAP_PERMITTED);
+    cap_clear_flag(caps, CAP_EFFECTIVE);
+    cap_clear_flag(caps, CAP_INHERITABLE);
+    // Bounding set stays intact - allows exec'd programs to get file caps
+
+    if (ambient_count > 0) {
+        // Restore only the ambient capabilities
+        cap_set_flag(caps, CAP_PERMITTED, ambient_count, ambient_caps, CAP_SET);
+        cap_set_flag(caps, CAP_EFFECTIVE, ambient_count, ambient_caps, CAP_SET);
+        cap_set_flag(caps, CAP_INHERITABLE, ambient_count, ambient_caps, CAP_SET);
+    }
 
     if (cap_set_proc(caps) != 0) {
         perror("cap_set_proc");
@@ -74,12 +105,27 @@ static void drop_privileges(void) {
     }
 
     cap_free(caps);
+
+    // Re-raise ambient caps so they survive exec
+    for (int i = 0; i < ambient_count; i++) {
+        if (prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, ambient_caps[i], 0, 0) != 0) {
+            perror("prctl PR_CAP_AMBIENT_RAISE");
+            exit(1);
+        }
+    }
 }
 
 int main(int argc, char *argv[]) {
     if (argc < 3) {
         fprintf(stderr, "Usage: %s <namespace> <command> [args...]\n", argv[0]);
         return 1;
+    }
+
+    // Sanitize environment variables (before any other operations)
+    for (char *unsec = UNSECURE_ENVVARS_TUNABLES UNSECURE_ENVVARS;
+         *unsec;
+         unsec = strchr(unsec, 0) + 1) {
+        unsetenv(unsec);
     }
 
     const char *ns = argv[1];

--- a/modules/vpntunnel.c
+++ b/modules/vpntunnel.c
@@ -1,0 +1,72 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sched.h>
+#include <sys/mount.h>
+#include <sys/prctl.h>
+#include <sys/capability.h>
+#include <errno.h>
+#include <fcntl.h>
+#define NETNS_DIR "/var/run/netns"
+static void do_mount(const char *src, const char *dst, const char *type, unsigned long flags) {
+    if (mount(src, dst, type, flags, NULL) != 0 && errno != ENOENT && errno != EEXIST)
+        perror("mount");
+}
+static void drop_privileges(void) {
+    // Drop bounding set while we still have CAP_SYS_ADMIN
+    for (int i = 0; i <= cap_max_bits(); i++) {
+        if (i == CAP_NET_RAW) continue;
+        prctl(PR_CAPBSET_DROP, i, 0, 0, 0); // ignore errors silently
+    }
+    // Now strip everything except CAP_NET_RAW from caps
+    cap_t caps = cap_get_proc();
+    cap_clear(caps);
+    cap_value_t keep = CAP_NET_RAW;
+    cap_set_flag(caps, CAP_INHERITABLE, 1, &keep, CAP_SET);
+    cap_set_flag(caps, CAP_PERMITTED, 1, &keep, CAP_SET);
+    cap_set_flag(caps, CAP_EFFECTIVE, 1, &keep, CAP_SET);
+    if (cap_set_proc(caps) != 0) { perror("cap_set_proc"); exit(1); }
+    cap_free(caps);
+    // Raise ambient so CAP_NET_RAW survives exec into any binary
+    if (prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, CAP_NET_RAW, 0, 0) != 0) {
+        perror("prctl PR_CAP_AMBIENT_RAISE");
+        exit(1);
+    }
+}
+int main(int argc, char *argv[]) {
+    if (argc < 3) {
+        fprintf(stderr, "Usage: %s <namespace> <command> [args...]\n", argv[0]);
+        return 1;
+    }
+    const char *ns = argv[1];
+    // Enter network namespace
+    char netns_path[256];
+    snprintf(netns_path, sizeof(netns_path), "%s/%s", NETNS_DIR, ns);
+    int nsfd = open(netns_path, O_RDONLY);
+    if (nsfd < 0) { perror("open netns"); return 1; }
+    if (setns(nsfd, CLONE_NEWNET) != 0) { perror("setns"); close(nsfd); return 1; }
+    close(nsfd);
+    // Create private mount namespace
+    if (unshare(CLONE_NEWNS) != 0) { perror("unshare CLONE_NEWNS"); return 1; }
+    // Don't propagate mounts to/from parent
+    if (mount("", "/", "", MS_SLAVE | MS_REC, NULL) != 0) { perror("mount --make-rslave"); return 1; }
+    // Bind-mount netns-specific files (same as ip netns exec does)
+    char buf[256];
+    snprintf(buf, sizeof(buf), "/etc/netns/%s/resolv.conf", ns);
+    do_mount(buf, "/etc/resolv.conf", NULL, MS_BIND);
+    snprintf(buf, sizeof(buf), "/etc/netns/%s/nsswitch.conf", ns);
+    do_mount(buf, "/etc/nsswitch.conf", NULL, MS_BIND);
+    snprintf(buf, sizeof(buf), "/etc/netns/%s/hosts", ns);
+    do_mount(buf, "/etc/hosts", NULL, MS_BIND);
+    // DNS leak prevention (same as systemd InaccessiblePaths)
+    do_mount("tmpfs", "/run/nscd", "tmpfs", 0);
+    do_mount("tmpfs", "/run/resolvconf", "tmpfs", 0);
+    do_mount("/dev/null", "/run/systemd/resolve/io.systemd.Resolve", NULL, MS_BIND);
+    // Drop all capabilities before exec
+    drop_privileges();
+    execvp(argv[2], &argv[2]);
+    perror("execvp");
+    return 1;
+}

--- a/modules/vpntunnel.c
+++ b/modules/vpntunnel.c
@@ -5,65 +5,155 @@
 #include <unistd.h>
 #include <sched.h>
 #include <sys/mount.h>
-#include <sys/prctl.h>
+#include <sys/stat.h>
 #include <sys/capability.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <net/if.h>
+
 #define NETNS_DIR "/var/run/netns"
-static void do_mount(const char *src, const char *dst, const char *type, unsigned long flags) {
-    if (mount(src, dst, type, flags, NULL) != 0 && errno != ENOENT && errno != EEXIST)
-        perror("mount");
-}
-static void drop_privileges(void) {
-    // Drop bounding set while we still have CAP_SYS_ADMIN
-    for (int i = 0; i <= cap_max_bits(); i++) {
-        if (i == CAP_NET_RAW) continue;
-        prctl(PR_CAPBSET_DROP, i, 0, 0, 0); // ignore errors silently
+#define NETNS_CONF_DIR "/etc/netns"
+#define NETNS_MAX_FILENAME 14  // "nsswitch.conf"
+
+// "/etc/netns" + "/" + name + "/" + "nsswitch.conf" + '\0'
+#define NETNS_PATH_MAX (sizeof(NETNS_CONF_DIR) + 1 + IFNAMSIZ + NETNS_MAX_FILENAME + 1)
+
+static int do_mount(const char *src, const char *dst, const char *type, unsigned long flags) {
+    if (mount(src, dst, type, flags, NULL) != 0) {
+        fprintf(stderr, "mount failed: src=%s, dst=%s: %s\n", src, dst, strerror(errno));
+        return -1;
     }
-    // Now strip everything except CAP_NET_RAW from caps
+    return 0;
+}
+
+static void mask_path_if_exists(const char *path) {
+    struct stat st;
+    if (stat(path, &st) == 0) {
+        // Path exists, so mount MUST succeed
+        if (S_ISDIR(st.st_mode)) {
+            if (mount("tmpfs", path, "tmpfs", 0, "size=0") != 0) {
+                fprintf(stderr, "Failed to mask directory %s: %s\n", path, strerror(errno));
+                exit(1);
+            }
+            if (mount(NULL, path, NULL, MS_REMOUNT | MS_RDONLY | MS_BIND, NULL) != 0) {
+                fprintf(stderr, "Failed to remount %s read-only: %s\n", path, strerror(errno));
+                exit(1);
+            }
+        } else {
+            if (mount("/dev/null", path, NULL, MS_BIND, NULL) != 0) {
+                fprintf(stderr, "Failed to mask file %s: %s\n", path, strerror(errno));
+                exit(1);
+            }
+            if (mount(NULL, path, NULL, MS_REMOUNT | MS_RDONLY | MS_BIND, NULL) != 0) {
+                fprintf(stderr, "Failed to remount %s read-only: %s\n", path, strerror(errno));
+                exit(1);
+            }
+        }
+    }
+    // Path doesn't exist - OK to ignore because of MS_PRIVATE
+}
+
+static void drop_privileges(void) {
+    // Drop all capabilities before exec.
+    // This makes the target program run completely unprivileged inside the namespace.
+    // If specific capabilities are needed (e.g., CAP_NET_BIND_SERVICE),
+    // set them on the target binary with: setcap cap_name+ep /path/to/binary,
+    // or with the securityWrappers option on NixOS.
     cap_t caps = cap_get_proc();
-    cap_clear(caps);
-    cap_value_t keep = CAP_NET_RAW;
-    cap_set_flag(caps, CAP_INHERITABLE, 1, &keep, CAP_SET);
-    cap_set_flag(caps, CAP_PERMITTED, 1, &keep, CAP_SET);
-    cap_set_flag(caps, CAP_EFFECTIVE, 1, &keep, CAP_SET);
-    if (cap_set_proc(caps) != 0) { perror("cap_set_proc"); exit(1); }
-    cap_free(caps);
-    // Raise ambient so CAP_NET_RAW survives exec into any binary
-    if (prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, CAP_NET_RAW, 0, 0) != 0) {
-        perror("prctl PR_CAP_AMBIENT_RAISE");
+    if (caps == NULL) {
+        perror("cap_get_proc");
         exit(1);
     }
+
+    cap_clear(caps);  // Clear all capabilities - completely unprivileged
+
+    if (cap_set_proc(caps) != 0) {
+        perror("cap_set_proc");
+        exit(1);
+    }
+
+    cap_free(caps);
 }
+
 int main(int argc, char *argv[]) {
     if (argc < 3) {
         fprintf(stderr, "Usage: %s <namespace> <command> [args...]\n", argv[0]);
         return 1;
     }
+
     const char *ns = argv[1];
+
+    // Validate namespace name length
+    if (strlen(ns) >= IFNAMSIZ) {
+        fprintf(stderr, "Error: namespace name too long (max %d characters)\n", IFNAMSIZ - 1);
+        return 1;
+    }
+
+    // Validate no path traversal
+    if (strchr(ns, '/') != NULL || strcmp(ns, ".") == 0 || strcmp(ns, "..") == 0) {
+        fprintf(stderr, "Error: invalid namespace name\n");
+        return 1;
+    }
+
     // Enter network namespace
-    char netns_path[256];
+    char netns_path[sizeof(NETNS_DIR) + IFNAMSIZ];
     snprintf(netns_path, sizeof(netns_path), "%s/%s", NETNS_DIR, ns);
+
     int nsfd = open(netns_path, O_RDONLY);
-    if (nsfd < 0) { perror("open netns"); return 1; }
-    if (setns(nsfd, CLONE_NEWNET) != 0) { perror("setns"); close(nsfd); return 1; }
+    if (nsfd < 0) {
+        perror("open netns");
+        return 1;
+    }
+
+    if (setns(nsfd, CLONE_NEWNET) != 0) {
+        perror("setns");
+        close(nsfd);
+        return 1;
+    }
     close(nsfd);
+
     // Create private mount namespace
-    if (unshare(CLONE_NEWNS) != 0) { perror("unshare CLONE_NEWNS"); return 1; }
+    if (unshare(CLONE_NEWNS) != 0) {
+        perror("unshare CLONE_NEWNS");
+        return 1;
+    }
+
     // Don't propagate mounts to/from parent
-    if (mount("", "/", "", MS_SLAVE | MS_REC, NULL) != 0) { perror("mount --make-rslave"); return 1; }
-    // Bind-mount netns-specific files (same as ip netns exec does)
-    char buf[256];
+    if (mount("", "/", "", MS_PRIVATE | MS_REC, NULL) != 0) {
+        perror("mount --make-rprivate");
+        return 1;
+    }
+
+    // Bind-mount netns-specific files (same as ip netns exec does).
+    // More strict because we exit the program if any of the files are not
+    // present, as we require them for configuring DNS and preventing leaks.
+    char buf[NETNS_PATH_MAX];
+
     snprintf(buf, sizeof(buf), "/etc/netns/%s/resolv.conf", ns);
-    do_mount(buf, "/etc/resolv.conf", NULL, MS_BIND);
+    if (do_mount(buf, "/etc/resolv.conf", NULL, MS_BIND) != 0) {
+        return 1;
+    }
+
     snprintf(buf, sizeof(buf), "/etc/netns/%s/nsswitch.conf", ns);
-    do_mount(buf, "/etc/nsswitch.conf", NULL, MS_BIND);
+    if (do_mount(buf, "/etc/nsswitch.conf", NULL, MS_BIND) != 0) {
+        return 1;
+    }
+
     snprintf(buf, sizeof(buf), "/etc/netns/%s/hosts", ns);
-    do_mount(buf, "/etc/hosts", NULL, MS_BIND);
-    // DNS leak prevention (same as systemd InaccessiblePaths)
-    do_mount("tmpfs", "/run/nscd", "tmpfs", 0);
-    do_mount("tmpfs", "/run/resolvconf", "tmpfs", 0);
-    do_mount("/dev/null", "/run/systemd/resolve/io.systemd.Resolve", NULL, MS_BIND);
+    if (do_mount(buf, "/etc/hosts", NULL, MS_BIND) != 0) {
+        return 1;
+    }
+
+    // DNS leak prevention by masking system DNS service paths.
+    // Similar to systemd InaccessiblePaths, but more robust: MS_PRIVATE
+    // ensures these paths cannot become accessible even if the host adds
+    // or removes mounts after we enter the namespace.
+    mask_path_if_exists("/run/nscd");
+    mask_path_if_exists("/run/resolvconf");
+    mask_path_if_exists("/run/systemd/resolve/io.systemd.Resolve");
+    mask_path_if_exists("/run/systemd/resolve/stub-resolv.conf");
+    mask_path_if_exists("/run/systemd/resolve/resolv.conf");
+
     // Drop all capabilities before exec
     drop_privileges();
     execvp(argv[2], &argv[2]);

--- a/pkgs/vpn-tunnel.nix
+++ b/pkgs/vpn-tunnel.nix
@@ -1,0 +1,39 @@
+{
+  stdenv,
+  libcap,
+  srcOnly,
+  glibc,
+  lib,
+}: let
+  # glibc definitions of insecure environment variables
+  #
+  # We extract the single header file we need into its own derivation,
+  # so that we don't have to pull full glibc sources to build wrappers.
+  #
+  # They're taken from pkgs.glibc so that we don't have to keep as close
+  # an eye on glibc changes. Not every relevant variable is in this header,
+  # so we maintain a slightly stricter list in wrapper.c itself as well.
+  unsecvars = lib.overrideDerivation (srcOnly glibc) (
+    {name, ...}: {
+      name = "${name}-unsecvars";
+      installPhase = ''
+        mkdir $out
+        cp sysdeps/generic/unsecvars.h $out
+      '';
+    }
+  );
+in
+  stdenv.mkDerivation {
+    pname = "vpntunnel";
+    version = "0.1.0";
+    src = ./vpntunnel.c;
+    dontUnpack = true;
+    nativeBuildInputs = [libcap.dev];
+    CFLAGS = ["-lcap" "-O2" "-Wall"];
+    buildPhase = ''
+      $CC $CFLAGS $src -I${unsecvars} -o vpntunnel
+    '';
+    installPhase = ''
+      install -Dm755 vpntunnel $out/bin/vpntunnel
+    '';
+  }

--- a/pkgs/vpntunnel.c
+++ b/pkgs/vpntunnel.c
@@ -69,6 +69,24 @@ static void mask_path_if_exists(const char *path) {
 }
 
 static void drop_privileges(void) {
+    // Drop all capabilities before exec, preserving only ambient capabilities.
+    //
+    // This ensures vpntunnel acts as a transparent wrapper:
+    // - Drops vpntunnel's own CAP_SYS_ADMIN (from file caps or root)
+    // - Preserves ambient capabilities set by systemd (for service use)
+    // - Leaves bounding set intact (allows exec'd programs to get file caps)
+    //
+    // IMPORTANT: Ambient capabilities only work when vpntunnel has NO file
+    // capabilities. The kernel clears ambient caps when exec'ing a binary
+    // with file capabilities (security.capability xattr).
+    //
+    // Usage patterns:
+    // - Interactive (wrapper with file caps): No ambient caps, drops all
+    // - Systemd (unwrapped, no file caps): Preserves systemd AmbientCapabilities
+    //
+    // For systemd services needing ambient capabilities, use the unwrapped
+    // vpntunnel from the Nix store, NOT /run/wrappers/bin/vpntunnel.
+
     // Get current ambient capabilities
     cap_value_t ambient_caps[CAP_LAST_CAP + 1];
     int ambient_count = 0;


### PR DESCRIPTION
### Why

This project exposes a NixOS module to create and configure a networking namespace (netns) that will route all internet traffic via WireGuard. An explanation of how this works can be found on the [WireGuard website](https://www.wireguard.com/netns/#the-new-namespace-solution).
Currently the project only exposes a way to run systemd services inside of this netns by extending the systemd options set. An arbitrary binary can be run inside the netns like this `ip netns exec <netns> <cmd>`, but this leaks DNS since the filesystem is not isolated. It would be nice if an arbitrary binary could be run with the same isolation without relying on systemd and its sandboxing.

### What

This PR adds a C wrapper `vpntunnel` that can be used to run an arbitrary binary inside a netns while isolating the process from the host network and relevant filesystem paths. This means we can use our Wireguard netns and mask filesystem paths to prevent DNS leaks over UDP (other forms of DNS like DoT and DoH have not been tested. See disclaimer in the README).
The filesystem isolation of `vpntunnel` is better than the systemd mounts, since it marks the mounts with MS_PRIVATE, while systemd forces us to use MS_SHARED, which propagates mounts to/from the host. See [The Container Interface](https://systemd.io/CONTAINER_INTERFACE/) for details.
The unsecure environment variables specified by glibc are sanitized together with a legacy list taken directly from the [nixpkgs security wrapper](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/security/wrappers/wrapper.c).
The `CAP_SYS_ADMIN` capability is required by `vpntunnel`, but is dropped before executing the wrapped binary. The capability bounding set is left intact, and ambient caps are preserved if `vpntunnel` is run without file caps, which requires `CAP_SYS_ADMIN` to be specified as an ambient capability (in this case the wrapped binary will inherit the caps, so be careful). See the `drop_privileges` function for details.

### Usage

```nix
# configuration.nix

vpnNamespaces.<netns> = { ... };
programs.vpntunnel.enable = true;
```

```bash
$ vpntunnel <netns> <cmd>

# Example
$ vpntunnel wg firefox
```

> [!IMPORTANT]
> Be cautious when wrapping a program that already has an instance running.
> For example, browsers such as Firefox will use the existing instance and simply open a new window. This means the new window is still running on the host and not inside the netns!